### PR TITLE
Make update_taxonomy output distinct

### DIFF
--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -360,7 +360,8 @@ update_taxonomy <- function(aligned_names,
   taxa_out <-
     dplyr::bind_rows(taxa_APC,
               taxa_APNI) %>%
-    dplyr::arrange(aligned_name)
+    dplyr::arrange(aligned_name) %>%
+    dplyr::distinct()
   
   if (!is.null(output)) {
     readr::write_csv(taxa_out, output)


### PR DESCRIPTION
Added `dplyr::distinct()` function in at the end of `update_taxonomy` function such that `taxa_out` shouldn't contain any duplicate rows. 